### PR TITLE
Call testcaseDone after failed assertion

### DIFF
--- a/testmybot/lib/testbuilder.js
+++ b/testmybot/lib/testbuilder.js
@@ -48,10 +48,10 @@ function setupTestSuite(testcaseCb, assertCb, failCb, hears, says) {
             (err) => {
               if (err) {
                 log.info(testcase.name + ' failed: ' + err);
-                failCb(err); 
+              } else {
+                log.info(testcase.name + ' finished, calling done function.');
               }
-              log.info(testcase.name + ' ready, calling done function.');
-              testcaseDone();
+              testcaseDone(err);
             });
 
         }, 


### PR DESCRIPTION
This change makes Mocha finish testcase immediately after failed assertion.
Jasmine had no such issue and is not affected by this change (output stays the same).

Please tell me if there are any side effects caused by not calling calling failCb.

Fixes #14 
