### PR TITLE
Use unix eol in convo files in all systems

### DIFF
--- a/testmybot/lib/convo.js
+++ b/testmybot/lib/convo.js
@@ -12,7 +12,7 @@ const readdir = Promise.promisify(require('fs').readdir);
 const readdirSync = require('fs').readdirSync;
 const mkdirp = Promise.promisify(require('mkdirp'));
 const async = require('async');
-const EOL = require('os').EOL;
+const EOL = "\n";
 const isJSON = require('is-json');
 const _ = require('lodash');
 


### PR DESCRIPTION
`\n` works on all systems,
I want to use it on Windows and I currently can't.

All that OS EOL gives is unnecessary confusion and errors.