### PR TITLE
Mocha helper shows error message

### DIFF
--- a/testmybot/helper/mocha.js
+++ b/testmybot/helper/mocha.js
@@ -13,7 +13,7 @@ module.exports.setupMochaTestCases = function(timeout) {
     (response, tomatch, msg) => {
       expect(response).to.include(tomatch, msg);
     },
-    (err) => expect.fail(err),
+    (err) => expect.fail(null, null, err),
     testmybot.hears,
     testmybot.says
   );


### PR DESCRIPTION
Fixes #17

Output before:
```
Unhandled rejection AssertionError: expect.fail()
    at module.exports.setupMochaTestCases.testbuilder.setupTestSuite (E:\projects\botkit-starter-web\node_modules\testmybot\helper\mocha.js:16:21)
```

Output after:
```
Unhandled rejection AssertionError: Conversation is empty
    at testbuilder.setupTestSuite (E:\projects\botkit-starter-web\node_modules\testmybot\helper\mocha.js:16:21)
```