### PR TITLE
Fail test if conversation is empty

### DIFF
--- a/testmybot/lib/convo.js
+++ b/testmybot/lib/convo.js
@@ -143,7 +143,10 @@ function readConvo(filename) {
           convo.description = currentLines.slice(1).join(EOL);
         }
       }
-      
+
+      if (convo.conversation.length === 0) {
+        throw 'Conversation is empty';
+      }
       readConvoResolve(convo);
       
     }).catch((err) => readConvoReject(err));


### PR DESCRIPTION
If conversation is empty it isn't testing anything, so it should fail.

This change should help to understand issue caused by using `\n` on Windows easier.
It is very confusing for new users like me.