### PR TITLE
Provide transcript for handling

### DIFF
--- a/src/helpers/jasmine.js
+++ b/src/helpers/jasmine.js
@@ -4,7 +4,7 @@ const BotiumBindings = require('../BotiumBindings')
 
 const defaultTimeout = process.env.BOTIUM_JASMINE_TIMEOUT || 60000
 
-const setupJasmineTestCases = ({ timeout = defaultTimeout, testcaseSelector, bb } = {}) => {
+const setupJasmineTestCases = ({ timeout = defaultTimeout, testcaseSelector, onTranscriptReady, bb } = {}) => {
   bb = bb || new BotiumBindings()
 
   bb.setupTestSuite(
@@ -24,12 +24,13 @@ const setupJasmineTestCases = ({ timeout = defaultTimeout, testcaseSelector, bb 
         timeout)
       return true
     },
+    onTranscriptReady,
     null,
     (err) => fail(err)
   )
 }
 
-const setupJasmineTestSuite = ({ timeout = defaultTimeout, name, testcaseSelector, bb } = {}) => {
+const setupJasmineTestSuite = ({ timeout = defaultTimeout, name, testcaseSelector, onTranscriptReady, bb } = {}) => {
   bb = bb || new BotiumBindings()
   name = name || bb.getTestSuiteName()
 
@@ -50,7 +51,7 @@ const setupJasmineTestSuite = ({ timeout = defaultTimeout, name, testcaseSelecto
       bb.afterAll().then(() => done()).catch(done.fail)
     }, timeout)
 
-    setupJasmineTestCases({ timeout, testcaseSelector, bb })
+    setupJasmineTestCases({ timeout, testcaseSelector, onTranscriptReady, bb })
   })
 }
 

--- a/src/helpers/jest.js
+++ b/src/helpers/jest.js
@@ -2,7 +2,7 @@
 
 const BotiumBindings = require('../BotiumBindings')
 
-const setupJestTestCases = ({ testcaseSelector, bb } = {}) => {
+const setupJestTestCases = ({ testcaseSelector, onTranscriptReady, bb } = {}) => {
   bb = bb || new BotiumBindings()
 
   let testCount = 0
@@ -13,14 +13,15 @@ const setupJestTestCases = ({ testcaseSelector, bb } = {}) => {
       testCount++
       test(testcase.header.name, testcaseFunction)
       return true
-    }
+    },
+    onTranscriptReady
   )
   if (testCount === 0) {
     it.skip('skip empty test suite', () => {})
   }
 }
 
-const setupJestTestSuite = ({ name, testcaseSelector, bb } = {}) => {
+const setupJestTestSuite = ({ name, testcaseSelector, onTranscriptReady, bb } = {}) => {
   bb = bb || new BotiumBindings()
   name = name || bb.getTestSuiteName()
 
@@ -41,7 +42,7 @@ const setupJestTestSuite = ({ name, testcaseSelector, bb } = {}) => {
       bb.afterAll().then(() => done()).catch(done)
     })
 
-    setupJestTestCases({ bb, testcaseSelector })
+    setupJestTestCases({ bb, testcaseSelector, onTranscriptReady })
   })
 }
 

--- a/src/helpers/mocha.js
+++ b/src/helpers/mocha.js
@@ -4,7 +4,7 @@ const BotiumBindings = require('../BotiumBindings')
 
 const defaultTimeout = process.env.BOTIUM_MOCHA_TIMEOUT || 60000
 
-const setupMochaTestCases = ({ timeout = defaultTimeout, testcaseSelector, bb } = {}) => {
+const setupMochaTestCases = ({ timeout = defaultTimeout, testcaseSelector, onTranscriptReady, bb } = {}) => {
   bb = bb || new BotiumBindings()
 
   bb.setupTestSuite(
@@ -13,11 +13,12 @@ const setupMochaTestCases = ({ timeout = defaultTimeout, testcaseSelector, bb } 
 
       it(testcase.header.name, testcaseFunction).timeout(timeout)
       return true
-    }
+    },
+    onTranscriptReady
   )
 }
 
-const setupMochaTestSuite = ({ timeout = defaultTimeout, name, testcaseSelector, bb } = {}) => {
+const setupMochaTestSuite = ({ timeout = defaultTimeout, name, testcaseSelector, onTranscriptReady, bb } = {}) => {
   bb = bb || new BotiumBindings()
   name = name || bb.getTestSuiteName()
 
@@ -39,7 +40,7 @@ const setupMochaTestSuite = ({ timeout = defaultTimeout, name, testcaseSelector,
       bb.afterAll().then(() => done()).catch(done)
     })
 
-    setupMochaTestCases({ timeout, testcaseSelector, bb })
+    setupMochaTestCases({ timeout, testcaseSelector, onTranscriptReady, bb })
   })
 }
 


### PR DESCRIPTION
Based on the issue #132 , we are unable to get transcript in the reports of the test runners such as Jest, Mocha or Jasmine. 

The following changes adds a new callback `onTranscriptReady` to the setup functions for Jest, Mocha and Jasmine.
Using this callback we will be able to retrieve the transcription and can be added to our reports when required.

The following example demonstrates the usage of `onTranscriptReady` callback to add the transcription to the allure reports for a Jest project.

```js
const BotiumBindings = require('botium-bindings');
const allure = require('allure-js-commons')

const onTranscriptReady = (transcript) => {
    console.log(transcript, 'transcription')
    allure.attachment('Conversation Log', transcript.prettifyActual(), allure.ContentType.TEXT)
}

BotiumBindings.helper.jest().setupJestTestSuite({ bb: new BotiumBindings({ convodirs: [__dirname]}), onTranscriptReady });
```

This is how it looks in the allure report:
<img width="1499" height="737" alt="Screenshot 2025-10-27 at 12 43 11 AM" src="https://github.com/user-attachments/assets/d91ca7a2-5e81-466f-9006-7ccd28713891" />
